### PR TITLE
fix music not found; add share_url,music_share_url

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -99,6 +99,14 @@ class Scraper:
                 print("正在请求抖音API链接: " + '\n' + api_url)
                 # 将回执以JSON格式处理
                 js = json.loads(requests.get(url=api_url, headers=headers, proxies=self.proxies).text)
+                aweme_id = str(js['item_list'][0]['aweme_id'])
+                share_url = re.sub("/\\?.*", "", js['item_list'][0]['share_url'])
+                if share_url is None:
+                    share_url = ("https://www.iesdouyin.com/share/video/" + aweme_id) if aweme_id is not None else original_url;
+                try:
+                    music_share_url = "https://www.iesdouyin.com/share/music/" + str(js['item_list'][0]['music']['mid'])
+                except:
+                    music_share_url = None
                 # 判断是否为图集
                 if js['item_list'][0]['images'] is not None:
                     print("类型 = 图集")
@@ -130,6 +138,7 @@ class Scraper:
                             album_music_id = str(js['item_list'][0]['music']['id'])
                             # 图集BGM MID
                             album_music_mid = str(js['item_list'][0]['music']['mid'])
+                            break;
                         else:
                             # 图集BGM链接
                             album_music = album_music_title = album_music_author = album_music_id = album_music_mid = 'No BGM found '
@@ -163,6 +172,8 @@ class Scraper:
                                   'url_type': url_type,
                                   'platform': 'douyin',
                                   'original_url': original_url,
+                                  'share_url': share_url,
+                                  'music_share_url': music_share_url,
                                   'api_url': api_url,
                                   'album_aweme_id': album_aweme_id,
                                   'album_title': album_title,
@@ -234,6 +245,7 @@ class Scraper:
                             video_music_id = str(js['item_list'][0]['music']['id'])
                             # 视频BGM MID
                             video_music_mid = str(js['item_list'][0]['music']['mid'])
+                            break;
                         else:
                             video_music = video_music_title = video_music_author = video_music_id = video_music_mid = 'No BGM found'
                     # 视频ID
@@ -268,6 +280,8 @@ class Scraper:
                                   'url_type': url_type,
                                   'platform': 'douyin',
                                   'original_url': original_url,
+                                  'share_url': share_url,
+                                  'music_share_url': music_share_url,
                                   'api_url': api_url,
                                   'video_title': video_title,
                                   'nwm_video_url': video_url,


### PR DESCRIPTION
**修改了音乐链接找不到（scraper.py 循环里增加了break）**

另外在返回里增加了两个字段

1. **share_url**：

&emsp;&emsp;由于 [https://v.douyin.com/6RHvnJq/](url) 这种格式的链接，同一个视频多次点击分享，会有不同的链接，但都指向的是同一个视频，
&emsp;&emsp;而用aweme_id则会不变 [https://www.iesdouyin.com/share/video/7139405476835364103](url)，这种格式链接打开会直接调用抖音app

2. **music_share_url**:

&emsp;&emsp;方便同时搜索同一个系列视频，这种格式链接打开会直接调用抖音app打开音乐主页
   
