### PR TITLE
fix: use try/finally for Bilibili temp file cleanup in merge_bilibili_video_audio

### DIFF
--- a/app/api/endpoints/download.py
+++ b/app/api/endpoints/download.py
@@ -54,22 +54,24 @@ async def merge_bilibili_video_audio(video_url: str, audio_url: str, request: Re
     """
     下载并合并 Bilibili 的视频流和音频流
     """
+    video_temp_path = None
+    audio_temp_path = None
     try:
         # 创建临时文件
         with tempfile.NamedTemporaryFile(suffix='.m4v', delete=False) as video_temp:
             video_temp_path = video_temp.name
         with tempfile.NamedTemporaryFile(suffix='.m4a', delete=False) as audio_temp:
             audio_temp_path = audio_temp.name
-        
+
         # 下载视频流
         video_success = await fetch_data_stream(video_url, request, headers=headers, file_path=video_temp_path)
         # 下载音频流
         audio_success = await fetch_data_stream(audio_url, request, headers=headers, file_path=audio_temp_path)
-        
+
         if not video_success or not audio_success:
             print("Failed to download video or audio stream")
             return False
-        
+
         # 使用 FFmpeg 合并视频和音频
         ffmpeg_cmd = [
             'ffmpeg', '-y',  # -y 覆盖输出文件
@@ -80,7 +82,7 @@ async def merge_bilibili_video_audio(video_url: str, audio_url: str, request: Re
             '-f', 'mp4',     # 确保输出格式为MP4
             output_path
         ]
-        
+
         print(f"FFmpeg command: {' '.join(ffmpeg_cmd)}")
         result = subprocess.run(ffmpeg_cmd, capture_output=True, text=True)
         print(f"FFmpeg return code: {result.returncode}")
@@ -88,25 +90,21 @@ async def merge_bilibili_video_audio(video_url: str, audio_url: str, request: Re
             print(f"FFmpeg stderr: {result.stderr}")
         if result.stdout:
             print(f"FFmpeg stdout: {result.stdout}")
-        
-        # 清理临时文件
-        try:
-            os.unlink(video_temp_path)
-            os.unlink(audio_temp_path)
-        except:
-            pass
-        
+
         return result.returncode == 0
-        
+
     except Exception as e:
-        # 清理临时文件
-        try:
-            os.unlink(video_temp_path)
-            os.unlink(audio_temp_path)
-        except:
-            pass
         print(f"Error merging video and audio: {e}")
         return False
+
+    finally:
+        # 清理临时文件
+        for path in (video_temp_path, audio_temp_path):
+            if path:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
 
 @router.get("/download", summary="在线下载抖音|TikTok|Bilibili视频/图片/Online download Douyin|TikTok|Bilibili video/image")
 async def download_file_hybrid(request: Request,


### PR DESCRIPTION
## Summary
- Refactor  to use a  block instead of  for temp file cleanup
- Initialize  and  to  before the try block so the  clause can safely clean them up even if creation fails
- Convert bare  to  to catch only file-not-found errors

## Problem
The original code has a temp file leak:  and  are assigned inside the  statements but declared only within the  block. If  throws an exception before assignment (e.g., disk full, permission error), the variables are unbound and the cleanup code crashes. Additionally, bare  is a Python anti-pattern.

## Solution
- Move variable declarations before  with  sentinel
- Use  pattern (not ) so cleanup always runs regardless of how the function exits
- Guard cleanup with  to skip cleanup for 
- Replace bare  with  since  only raises  (subclass of OSError) when the file doesn't exist

## Tests
No existing tests for this function — manual verification:
-  creates both paths → finally cleans both
- If  throws before assignment → variables stay  → finally skips cleanup (no NameError)
- If ffmpeg fails → return  → finally still runs → temp files cleaned

## Risk / Compatibility
- Risk: LOW — behavior change is strictly correct (no functional difference for the success case; the bug fix prevents file leaks on error paths)
- Affects: runtime behavior (error path temp file cleanup only)
- No public API changes