### PR TITLE
Add fetch_user_collection_list API and collectionId support

### DIFF
--- a/app/api/endpoints/tiktok_web.py
+++ b/app/api/endpoints/tiktok_web.py
@@ -262,6 +262,57 @@ async def fetch_user_collect(request: Request,
                                     )
         raise HTTPException(status_code=status_code, detail=detail.dict())
 
+@router.get("/fetch_user_collection_list",
+            response_model=ResponseModel,
+            summary="获取收藏列表/Get user favorite lists")
+async def fetch_user_collection_list(request: Request,
+                             cookie: str = Query(example="Your_Cookie", description="用户cookie/User cookie"),
+                             secUid: str = Query(example="Your_SecUid", description="用户secUid/User secUid"),
+                             cursor: int = Query(default=0, description="翻页游标/Page cursor"),
+                             count: int = Query(default=30, description="每页数量/Number per page"),
+                             coverFormat: int = Query(default=2, description="封面格式/Cover format"),
+                             needPinnedItemIds: str = Query(default="false", description="需要置顶项ID/Need pinned item ids"),
+                             publicOnly: str = Query(default="false", description="仅公开项目/Only public items")
+):
+    """
+    # [English]
+    ### Purpose:
+    - Get user favorite lists
+    - Note: This interface can currently only get your own favorites list, you need to provide your account cookie.
+    ### Parameters:
+    - cookie: User cookie
+    - secUid: User secUid
+    - cursor: Page cursor
+    - count: Number per page
+    - coverFormat: Cover format
+    - needPinnedItemIds: Need pinned item ids
+    - publicOnly: Public only
+    ### Return:
+    - User favorites
+
+    # [示例/Example]
+    cookie = "Your_Cookie"
+    secUid = "Your_SecUid"
+    cursor = 0
+    count = 30
+    coverFormat = 2
+    needPinnedItemIds = "false"
+    publicOnly = "false"
+    """
+    try:
+        data = await TikTokWebCrawler.fetch_user_collection_list(cookie, secUid, cursor, count, coverFormat, needPinnedItemIds, publicOnly)
+        return ResponseModel(code=200,
+                             router=request.url.path,
+                             data=data)
+    except Exception as e:
+        status_code = 400
+        detail = ErrorResponseModel(code=status_code,
+                                    router=request.url.path,
+                                    params=dict(request.query_params),
+                                    )
+        raise HTTPException(status_code=status_code, detail=detail.dict())
+
+
 
 # 获取用户的播放列表
 @router.get("/fetch_user_play_list",

--- a/app/api/endpoints/tiktok_web.py
+++ b/app/api/endpoints/tiktok_web.py
@@ -214,7 +214,9 @@ async def fetch_user_collect(request: Request,
                              secUid: str = Query(example="Your_SecUid", description="用户secUid/User secUid"),
                              cursor: int = Query(default=0, description="翻页游标/Page cursor"),
                              count: int = Query(default=30, description="每页数量/Number per page"),
-                             coverFormat: int = Query(default=2, description="封面格式/Cover format")):
+                             coverFormat: int = Query(default=2, description="封面格式/Cover format"),
+                             collectionId: str | None = Query(default=None, description="收藏夹ID/Collection ID"),
+):
     """
     # [中文]
     ### 用途:
@@ -223,6 +225,7 @@ async def fetch_user_collect(request: Request,
     ### 参数:
     - cookie: 用户cookie
     - secUid: 用户secUid
+    - collectionId: 收藏夹ID
     - cursor: 翻页游标
     - count: 每页数量
     - coverFormat: 封面格式
@@ -236,6 +239,7 @@ async def fetch_user_collect(request: Request,
     ### Parameters:
     - cookie: User cookie
     - secUid: User secUid
+    - collectionId: Collection ID
     - cursor: Page cursor
     - count: Number per page
     - coverFormat: Cover format
@@ -245,12 +249,13 @@ async def fetch_user_collect(request: Request,
     # [示例/Example]
     cookie = "Your_Cookie"
     secUid = "Your_SecUid"
+    collectionId = None
     cursor = 0
     count = 30
     coverFormat = 2
     """
     try:
-        data = await TikTokWebCrawler.fetch_user_collect(cookie, secUid, cursor, count, coverFormat)
+        data = await TikTokWebCrawler.fetch_user_collect(cookie, secUid, cursor, count, coverFormat, collectionId)
         return ResponseModel(code=200,
                              router=request.url.path,
                              data=data)

--- a/crawlers/tiktok/web/endpoints.py
+++ b/crawlers/tiktok/web/endpoints.py
@@ -27,6 +27,9 @@ class TikTokAPIEndpoints:
     # 用户收藏 (User Collect)
     USER_COLLECT = f"{TIKTOK_DOMAIN}/api/user/collect/item_list/"
 
+    # 用户收藏详情 (User Collect specific)
+    USER_COLLECT_SPECIFIC = f"{TIKTOK_DOMAIN}/api/collection/item_list/"
+
     # 用户收藏列表 (User Collection List)
     USER_COLLECTION_LIST = f"{TIKTOK_DOMAIN}/api/user/collection_list/"
 

--- a/crawlers/tiktok/web/endpoints.py
+++ b/crawlers/tiktok/web/endpoints.py
@@ -27,6 +27,9 @@ class TikTokAPIEndpoints:
     # 用户收藏 (User Collect)
     USER_COLLECT = f"{TIKTOK_DOMAIN}/api/user/collect/item_list/"
 
+    # 用户收藏列表 (User Collection List)
+    USER_COLLECTION_LIST = f"{TIKTOK_DOMAIN}/api/user/collection_list/"
+
     # 用户播放列表 (User Play List)
     USER_PLAY_LIST = f"{TIKTOK_DOMAIN}/api/user/playlist/"
 

--- a/crawlers/tiktok/web/models.py
+++ b/crawlers/tiktok/web/models.py
@@ -107,6 +107,8 @@ class UserCollect(BaseRequestModel):
     count: int = 30
     cursor: int = 0
     secUid: str
+    collectionId: str | None = None
+    sourceType: int = 113
 
 
 class UserCollectionList(BaseRequestModel):

--- a/crawlers/tiktok/web/models.py
+++ b/crawlers/tiktok/web/models.py
@@ -1,6 +1,7 @@
 from typing import Any
-from pydantic import BaseModel
 from urllib.parse import quote, unquote
+
+from pydantic import BaseModel
 
 from crawlers.tiktok.web.utils import TokenManager
 from crawlers.utils.utils import get_timestamp
@@ -106,6 +107,16 @@ class UserCollect(BaseRequestModel):
     count: int = 30
     cursor: int = 0
     secUid: str
+
+
+class UserCollectionList(BaseRequestModel):
+    cookie: str = ""
+    count: int = 30
+    cursor: int = 0
+    secUid: str
+    coverFormat: int = 2
+    needPinnedItemIds: str = "true"
+    publicOnly: str = "false"
 
 
 class UserPlayList(BaseRequestModel):

--- a/crawlers/tiktok/web/web_crawler.py
+++ b/crawlers/tiktok/web/web_crawler.py
@@ -164,7 +164,7 @@ class TikTokWebCrawler:
 
     # 获取用户的收藏列表
     async def fetch_user_collect(self, cookie: str, secUid: str, cursor: int = 0, count: int = 30,
-                                 coverFormat: int = 2):
+                                 coverFormat: int = 2, collectionId: str | None = None):
         # 获取TikTok的实时Cookie
         kwargs = await self.get_tiktok_headers()
         kwargs["headers"]["Cookie"] = cookie
@@ -172,10 +172,13 @@ class TikTokWebCrawler:
         base_crawler = BaseCrawler(proxies=kwargs["proxies"], crawler_headers=kwargs["headers"])
         async with base_crawler as crawler:
             # 创建一个用户收藏的BaseModel参数
-            params = UserCollect(cookie=cookie, secUid=secUid, cursor=cursor, count=count, coverFormat=coverFormat)
+            
+            params = UserCollect(cookie=cookie, secUid=secUid, cursor=cursor, count=count, coverFormat=coverFormat, collectionId=collectionId)
             # 生成一个用户收藏的带有加密参数的Endpoint
             endpoint = BogusManager.model_2_endpoint(
-                TikTokAPIEndpoints.USER_COLLECT, params.dict(), kwargs["headers"]["User-Agent"]
+                TikTokAPIEndpoints.USER_COLLECT if collectionId is None else TikTokAPIEndpoints.USER_COLLECT_SPECIFIC,
+                params.dict(),
+                kwargs["headers"]["User-Agent"]
             )
             response = await crawler.fetch_get_json(endpoint)
         return response

--- a/crawlers/tiktok/web/web_crawler.py
+++ b/crawlers/tiktok/web/web_crawler.py
@@ -58,6 +58,7 @@ from crawlers.tiktok.web.models import (
     UserLike,
     UserMix,
     UserCollect,
+    UserCollectionList,
     PostDetail,
     UserPlayList,
     PostComment,
@@ -175,6 +176,28 @@ class TikTokWebCrawler:
             # 生成一个用户收藏的带有加密参数的Endpoint
             endpoint = BogusManager.model_2_endpoint(
                 TikTokAPIEndpoints.USER_COLLECT, params.dict(), kwargs["headers"]["User-Agent"]
+            )
+            response = await crawler.fetch_get_json(endpoint)
+        return response
+
+    # Get user collection lists / 获取收藏列表
+    async def fetch_user_collection_list(
+        self, cookie: str, secUid: str, cursor: int = 0, count: int = 30, coverFormat: int = 2, needPinnedItemIds: str = "false", publicOnly: str = "false"
+    ):
+        kwargs = await self.get_tiktok_headers()
+        kwargs["headers"]["Cookie"] = cookie
+
+        base_crawler = BaseCrawler(
+            proxies=kwargs["proxies"], crawler_headers=kwargs["headers"]
+        )
+        async with base_crawler as crawler:
+            params = UserCollectionList(
+                cookie=cookie, secUid=secUid, cursor=cursor, count=count, coverFormat=coverFormat, needPinnedItemIds=needPinnedItemIds, publicOnly=publicOnly
+            )
+            endpoint = BogusManager.model_2_endpoint(
+                TikTokAPIEndpoints.USER_COLLECTION_LIST,
+                params.dict(),
+                kwargs["headers"]["User-Agent"],
             )
             response = await crawler.fetch_get_json(endpoint)
         return response


### PR DESCRIPTION
This PR introduces a new API endpoint for accessing detailed information about user collections, such as their names.

It also adds a new `collectionId` parameter to `fetch_user_collect`. When specified, this parameter allows you to fetch information about a specific collection.
